### PR TITLE
Update discord-canary-0.0.118.tar.gz to 0.0.119

### DIFF
--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -41,8 +41,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://dl-canary.discordapp.net/apps/linux/0.0.118/discord-canary-0.0.118.tar.gz",
-                    "sha256": "b8eba47afec15e2f8cf3c9bde9beefbaa97bd051b97086af818808fbaa6924ab",
+                    "url": "https://dl-canary.discordapp.net/apps/linux/0.0.119/discord-canary-0.0.119.tar.gz",
+                    "sha256": "517fbe0bdaec2df59213e2fd88ebac157db574eca6244a50864ed6f3148df92f",
                     "strip-components": 0,
                     "x-checker-data": {
                         "type": "rotating-url",

--- a/com.discordapp.DiscordCanary.metainfo.xml
+++ b/com.discordapp.DiscordCanary.metainfo.xml
@@ -53,6 +53,7 @@
     <category>Network</category>
   </categories>
   <releases>
+    <release version="0.0.119" date="2021-02-08"/>
     <release version="0.0.118" date="2021-01-27"/>
     <release version="0.0.117" date="2021-01-27"/>
     <release version="0.0.116" date="2020-11-24"/>


### PR DESCRIPTION
Discord has released canary version 0.0.119, updated the client from 0.0.118 to 0.0.119.

See #5 