### PR TITLE
PipeWire 0.3 for Wayland screen sharing

### DIFF
--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -87,6 +87,27 @@
                         }
                     ]
                 },
+
+                
+
+            {
+             "name": "pipewire",
+             "buildsystem": "meson",
+             "config-opts": [
+                "-Dgstreamer=disabled",
+                "-Dman=false",
+                "-Dsystemd=false"
+             ],
+             "sources": [
+                    {
+                        "type": "git",
+                        "url": "https://gitlab.freedesktop.org/pipewire/pipewire.git",
+                        "tag": "0.2.7"
+                    }
+                ]
+            },
+
+
                 {
                     "name": "socat",
                     "sources": [
@@ -102,6 +123,7 @@
                         }
                     ]
                 }
+            
             ]
         }
     ]

--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -23,6 +23,7 @@
         "--env=XDG_CURRENT_DESKTOP=Unity",
         "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.kde.StatusNotifierWatcher",
+        "--filesystem=xdg-run/pipewire-0",
         "--talk-name=com.canonical.AppMenu.Registrar"
     ],
     "modules": [
@@ -36,6 +37,7 @@
                 "install -d /app/share/applications",
                 "sed -e 's/Icon=discord-canary/Icon=com.discordapp.DiscordCanary/' -e 's|Exec=/usr/share/discord-canary/DiscordCanary|Exec=discord-canary|' /app/discord-canary/discord-canary.desktop > /app/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 /app/discord-canary/discord.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png",
+                "desktop-file-edit --set-key=\"Exec\" --set-value=\"discord-canary --enable-features=WebRTCPipeWireCapturer %U\" ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 com.discordapp.DiscordCanary.metainfo.xml /app/share/metainfo/com.discordapp.DiscordCanary.metainfo.xml"
             ],
             "sources": [


### PR DESCRIPTION
Should fix screen sharing on Wayland, need to test.

We shouldn't need to build with PipeWire 0.2 since Discord canary is on Electron 13, so we can use PipeWire 0.3 from runtime.