### PR TITLE
Use native wayland when possible

### DIFF
--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -12,7 +12,8 @@
     ],
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=wayland",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",

--- a/discord-canary.sh
+++ b/discord-canary.sh
@@ -13,7 +13,7 @@ then
     FEATURES="$FEATURES,WaylandWindowDecorations"
 fi
 
-FLAGS="--ozone-platform-hint=auto \
+FLAGS="--ozone-platform=$XDG_SESSION_TYPE \
 --enable-gpu-rasterization \
 --enable-zero-copy \
 --enable-gpu-compositing \

--- a/discord-canary.sh
+++ b/discord-canary.sh
@@ -6,11 +6,9 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-FEATURES="UseSkiaRenderer"
-
 if [[ $XDG_SESSION_TYPE == "wayland" ]]
 then
-    FEATURES="$FEATURES,WaylandWindowDecorations"
+    FEATURES="WaylandWindowDecorations"
 fi
 
 FLAGS="--ozone-platform=$XDG_SESSION_TYPE \

--- a/discord-canary.sh
+++ b/discord-canary.sh
@@ -6,7 +6,7 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-FEATURES="UseSkiaRenderer,CanvasOopRasterization"
+FEATURES="UseSkiaRenderer"
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]]
 then
@@ -14,11 +14,6 @@ then
 fi
 
 FLAGS="--ozone-platform=$XDG_SESSION_TYPE \
---enable-gpu-rasterization \
---enable-zero-copy \
---enable-gpu-compositing \
---enable-native-gpu-memory-buffers \
---enable-oop-rasterization \
 --enable-features=$FEATURES"
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]

--- a/discord-canary.sh
+++ b/discord-canary.sh
@@ -6,7 +6,20 @@ socat $SOCAT_ARGS \
     &
 socat_pid=$!
 
-FLAGS='--enable-gpu-rasterization --enable-zero-copy --enable-gpu-compositing --enable-native-gpu-memory-buffers --enable-oop-rasterization --enable-features=UseSkiaRenderer,CanvasOopRasterization'
+FEATURES="UseSkiaRenderer,CanvasOopRasterization"
+
+if [[ $XDG_SESSION_TYPE == "wayland" ]]
+then
+    FEATURES="$FEATURES,WaylandWindowDecorations"
+fi
+
+FLAGS="--ozone-platform-hint=auto \
+--enable-gpu-rasterization \
+--enable-zero-copy \
+--enable-gpu-compositing \
+--enable-native-gpu-memory-buffers \
+--enable-oop-rasterization \
+--enable-features=$FEATURES"
 
 if [[ $XDG_SESSION_TYPE == "wayland" ]] && [ -c /dev/nvidia0 ]
 then


### PR DESCRIPTION
based on https://github.com/flathub/com.discordapp.Discord/pull/248, but since canary has been on electron 17 for a while this should work fine. 