### PR TITLE
Fix tray icon on kde wayland

### DIFF
--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -20,7 +20,8 @@
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=com.canonical.AppMenu.Registrar",
         "--talk-name=com.canonical.indicator.application",
-        "--talk-name=com.canonical.Unity.LauncherEntry"
+        "--talk-name=com.canonical.Unity.LauncherEntry",
+        "--own-name=org.kde.*"
     ],
     "modules": [
         {


### PR DESCRIPTION
title
caused by electron 22 using dbusmenu
still can't believe discord has switched to electron 22, already...