### PR TITLE
Fix app permissions

### DIFF
--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -13,6 +13,7 @@
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",

--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -22,7 +22,6 @@
         "--talk-name=com.canonical.AppMenu.Registrar",
         "--talk-name=com.canonical.indicator.application",
         "--talk-name=com.canonical.Unity",
-        "--own-name=org.kde.*",
         "--env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons",
         "--env=XDG_CURRENT_SESSION=KDE",
         "--env=ELECTRON_TRASH=gio"


### PR DESCRIPTION
* Add wayland socket permission (*I forgot to add it in #202*)
* Drop `--own-name=org.kde.*` (as stated in #78; indicator icon seems to be working fine)