### PR TITLE
Discord stable ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Discord Canary
+
+Discord is a free all-in-one messaging, voice and video client that's available on your computer and phone.
+
+This repo hosts the flatpak wrapper for [Discord Canary](https://canary.discord.com/), available at Flathub-Beta.
+
+```sh
+flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+flatpak install flathub com.discordapp.DiscordCanary
+flatpak run com.discordapp.DiscordCanary
+```
+
+## Limitations
+* This flatpak version of Discord cannot scan running processes to detect running games.
+* Default sandbox permissions for this package does not allow host filesystem access. You can attach files using "send file" menu, but "drag-n-drop" feature will not work.  
+  To work around this now, you can change sandbox permissions (for example, with [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) or with `flatpak override --filesystem=home com.discordapp.DiscordCanary`) to give Discord broader file system access, allowing drag-n-drop file attachments from more locations.
+* Rich Presence socket is not exposed for other applications by default.  
+  Please consult [Discord (Stable) wiki page](https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)) if you want to expose Discord's rich presence interface for other applications.
+
+## Opt-in features
+
+### Wayland support
+
+This package enables the flags to run on Wayland, however it is opt-in. To opt-in run:
+
+```sh
+flatpak override --user --socket=wayland com.discordapp.DiscordCanary
+```
+
+To opt-out do the same with `--nosocket=wayland`.
+
+
+### Startup flags customization
+
+You can change `DISCORD_FLAGS` env variable to add any required flags:
+```sh
+flatpak override --user --env=DISCORD_FLAGS=--required-flag com.discordapp.DiscordCanary
+```
+
+To reset env changes do the same with `--unset-env=DISCORD_FLAGS`

--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -59,7 +59,7 @@
                 "install -Dm755 /app/discord-canary/discord-canary.desktop /app/share/applications/${FLATPAK_ID}.desktop",
                 "install -Dm644 /app/discord-canary/discord.png /app/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png",
                 "install -Dm644 com.discordapp.DiscordCanary.metainfo.xml /app/share/appdata/com.discordapp.DiscordCanary.metainfo.xml",
-                "desktop-file-edit --set-icon=com.discordapp.DiscordCanary --set-key=Exec --set-value=com.discordapp.DiscordCanary /app/share/applications/${FLATPAK_ID}.desktop",
+                "desktop-file-edit --set-icon=com.discordapp.DiscordCanary --set-key=Exec --set-value=com.discordapp.DiscordCanary --add-mime-type=x-scheme-handler/discord /app/share/applications/${FLATPAK_ID}.desktop",
                 "patch-desktop-filename ${FLATPAK_DEST}/discord-canary/resources/app.asar"
             ],
             "sources": [

--- a/discord-canary.sh
+++ b/discord-canary.sh
@@ -9,7 +9,7 @@ socat_pid=$!
 WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
 FLAGS=("${DISCORD_FLAGS[@]}")
 
-if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" ]]
+if [[ -e "$XDG_RUNTIME_DIR/${WAYLAND_SOCKET}" || -e "${WAYLAND_DISPLAY}" ]]
 then
     FLAGS+=("--enable-features=WaylandWindowDecorations" "--ozone-platform-hint=auto")
 fi


### PR DESCRIPTION
Added readme.

Ported https://github.com/flathub/com.discordapp.Discord/commit/2a3a0799759ecc8067ba0d8fe953f50519ee5f7a and https://github.com/flathub/com.discordapp.Discord/commit/d0473ceffedbd381f386d9c914973f5d7ebd1248 to sync with stable Discord flatpak.