### PR TITLE
README.md: fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ This repo hosts the flatpak wrapper for [Discord Canary](https://canary.discord.
 
 ```sh
 flatpak remote-add --if-not-exists flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
-flatpak install flathub com.discordapp.DiscordCanary
+flatpak install flathub-beta com.discordapp.DiscordCanary
 flatpak run com.discordapp.DiscordCanary
 ```
 
 ## Limitations
 * This flatpak version of Discord cannot scan running processes to detect running games.
 * Default sandbox permissions for this package does not allow host filesystem access. You can attach files using "send file" menu, but "drag-n-drop" feature will not work.  
-  To work around this now, you can change sandbox permissions (for example, with [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) or with `flatpak override --filesystem=home com.discordapp.DiscordCanary`) to give Discord broader file system access, allowing drag-n-drop file attachments from more locations.
+  To work around this now, you can change sandbox permissions (for example, with [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) or with `flatpak override --user --filesystem=home com.discordapp.DiscordCanary`) to give Discord broader file system access, allowing drag-n-drop file attachments from more locations.
 * Rich Presence socket is not exposed for other applications by default.  
   Please consult [Discord (Stable) wiki page](https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc)) if you want to expose Discord's rich presence interface for other applications.
 


### PR DESCRIPTION
1. Suggest correct repo (Flathub-Beta) instead of Flathub (where Discord Canary is currently unavailable)    
2. For file system access suggest the "--user" flag as in other override commands