### PR TITLE
Add permission to read the pipewire socket

### DIFF
--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -16,6 +16,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
+        "--filesystem=xdg-run/pipewire-0",
         "--filesystem=xdg-run/speech-dispatcher",
         "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.kde.StatusNotifierWatcher",


### PR DESCRIPTION
This is needed for screensharing in Gamescope (Steam Deck in Gaming mode) where there's no xdg-desktop-portal with the screencast interface deployed yet, but screen content is available as a PipeWire node directly.