### PR TITLE
Add permission to read the pipewire socket

### DIFF
--- a/com.discordapp.DiscordCanary.json
+++ b/com.discordapp.DiscordCanary.json
@@ -16,6 +16,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
+        "--filesystem=xdg-run/pipewire-0",
         "--filesystem=xdg-run/speech-dispatcher",
         "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.kde.StatusNotifierWatcher",


### PR DESCRIPTION
This a duplicate for #666 that I'd like to revisit after talking with a Discord maintainer. 

This is required for streaming on the Steam Deck in game mode. Screensharing is a core feature to Discord and this is a similar permission for other popular screensharing apps like browsers. 