### PR TITLE
Hack mediapipe, add Russian translation

### DIFF
--- a/com.discordapp.DiscordCanary.metainfo.xml
+++ b/com.discordapp.DiscordCanary.metainfo.xml
@@ -6,7 +6,8 @@
   <developer id="com.discord">
     <name>Discord Inc.</name>
   </developer>
-  <summary>Messaging, Voice, and Video Client (Early Access)</summary>
+  <summary>Talk, play, hang out (Early Access)</summary>
+  <summary xml:lang="ru">Общайся, играй, зависай (Ранний доступ)</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
   <url type="homepage">https://discordapp.com</url>
@@ -16,37 +17,55 @@
   <icon type="remote" height="256" width="256">https://github.com/flathub/com.discordapp.DiscordCanary/raw/master/com.discordapp.DiscordCanary.png</icon>
   <description>
     <p>**NOTE: This wrapper is not verified by, affiliated with, or supported by Discord.**</p>
+    <p xml:lang="ru">**ВНИМАНИЕ: Данная оболочка не проверена Discord, не связана и не поддерживается им.**</p>
     <p>Discord is a free all in one messaging, voice, and video client thats available on your computer and phone.</p>
+    <p xml:lang="ru">Discord — бесплатный клиент для переписки, голосового и видеообщения, доступный и на компьютере, и на телефоне.</p>
     <p>Whether you’re part of a school club, gaming group, worldwide art community, or just a handful of friends that want to spend time together, Discord makes it easy to talk every day and hang out more often.</p>
+    <p xml:lang="ru">Школьный кружок, игровое комьюнити, международное сообщество художников или просто компания друзей, которым хочется быть вместе, — с Discord легко общаться каждый день и чаще проводить время сообща.</p>    
     <ul>
       <li>Talk to your friends with messaging, voice, and video in a "Direct Message" (1 other person), group chat (up to 10 people), or a multi-channel server (practically infinite maximum members).</li>
+      <li xml:lang="ru">Общайтесь с друзьями текстом, голосом и по видео — в личных сообщениях (один собеседник), групповом чате (до 10 человек) или на сервере с множеством каналов (число участников практически не ограничено).</li>
       <li>Discord servers are organized into topic-based channels where you can collaborate, share, and just talk about your day without clogging up a group chat.</li>
+      <li xml:lang="ru">Серверы Discord разделены на тематические каналы: в них можно работать сообща, делиться находками и просто рассказывать, как прошёл день, не засоряя общий чат.</li>
       <li>Grab a seat in a voice channel when you’re free. Friends in your server can see you’re around and instantly pop in to talk without having to call.</li>
+      <li xml:lang="ru">Загляните в голосовой канал, когда освободитесь. Друзья на сервере увидят, что вы на месте, и присоединятся к разговору сразу — без всяких звонков.</li>
       <li>Get a community of any size running with moderation tools and custom member access. Give members special powers, set up private channels, and more.</li>
+      <li xml:lang="ru">Развивайте сообщество любого размера: к вашим услугам инструменты модерации и гибкая настройка доступа. Выдавайте участникам особые права, создавайте закрытые каналы и не только.</li>
       <li>Low-latency voice and video feels like you’re in the same room. Wave hello over video, watch friends stream their games, or gather up and have a drawing session with screen share.</li>
+      <li xml:lang="ru">Голос и видео почти без задержек — ощущение, будто вы в одной комнате. Помашите друг другу по видеосвязи, посмотрите, как друзья стримят свои игры, или соберитесь порисовать вместе, включив демонстрацию экрана.</li>
       <li>Available on Linux, macOS, Windows, iOS, Android, and your web browser.</li>
+      <li xml:lang="ru">Работает на Linux, macOS, Windows, iOS, Android и прямо в браузере.</li>
     </ul>
+    <p>Discord is written in Javascript, React, Elixir, and Rust. The desktop application uses the electron framework.</p>
+    <p xml:lang="ru">Discord написан на JavaScript, React, Elixir и Rust. Настольное приложение построено на фреймворке Electron.</p>
+    <p>The flatpak version runs in a sandbox to provide better safety and privacy for users. However, this sandboxing prevents the following features from working out of the box: Game Activity, Unrestricted File Access, Rich Presence. Check the README in the Github repo for details.</p>
+    <p xml:lang="ru">Версия для Flatpak работает в песочнице — так безопаснее и лучше для приватности. Но из-за изоляции некоторые возможности не работают сразу после установки: игровая активность (Game Activity), неограниченный доступ к файлам и Rich Presence. Подробности — в файле README в репозитории на GitHub.</p>
   </description>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://discord.com/assets/882599fca31a23ad38bd47db302b2a00.png</image>
       <caption>Talk on an invite only server</caption>
+      <caption xml:lang="ru">Общайся на серверах с доступом только по приглашениям</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://discord.com/assets/43fb8531fc13f02eb5f3c3e16d7fd1a7.png</image>
       <caption>Voice and Video</caption>
+      <caption xml:lang="ru">Голосовая и видеосвязь</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://discord.com/assets/8626705c42db1fee19fc95fff7480bf8.png</image>
       <caption>Dark Mode Window</caption>
+      <caption xml:lang="ru">Окно в тёмной теме</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://discord.com/assets/783ec8164addfd314cab6b0fa4ef6fc5.png</image>
       <caption>Light Mode Window</caption>
+      <caption xml:lang="ru">Окно в светлой теме</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://discord.com/assets/489dc2b446be5c305571ad96b845c776.png</image>
       <caption>Available on Linux, macOS, Windows, iOS, Android, and your web browser</caption>
+      <caption xml:lang="ru">Доступен на Linux, macOS, Windows, iOS, Android и в вашем веб-браузере</caption>
     </screenshot>
   </screenshots>
   <branding>

--- a/com.discordapp.DiscordCanary.yaml
+++ b/com.discordapp.DiscordCanary.yaml
@@ -23,7 +23,6 @@ finish-args:
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.indicator.application
   - --talk-name=com.canonical.Unity
-  - --system-talk-name=org.freedesktop.UPower
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
   - --env=ELECTRON_TRASH=gio
 
@@ -117,6 +116,25 @@ modules:
         set -e
         jq '.newUpdater = false | .localModulesRoot = "/app/discord-canary/modules"' /app/discord-canary/resources/build_info.json > tmp.json
         mv tmp.json /app/discord-canary/resources/build_info.json
+      # HACK: MediaPipe (video backgrounds / selfie segmentation) opens discord_voice *.tflite
+      #       models with O_RDWR. /app is mounted read-only, so the open fails with EACCES and the
+      #       camera goes black (see https://github.com/flathub/com.discordapp.Discord/issues/650).
+      #       Flatpak cannot ship files into the per-user writable tree at build time (/var/data is
+      #       created empty at runtime), so stash the real models under /app and replace them in the
+      #       module dir with symlinks to /var/data/mediapipe_models; discord.sh copies the stash
+      #       there on launch. Globbing *.tflite picks up any models Discord adds later.
+      - |
+        set -eu
+        voice=/app/discord-canary/modules/discord_voice
+        store=/app/discord-canary/mediapipe_models
+        # /var/data is Flatpak's alias for $XDG_DATA_HOME; keep an absolute path in the symlink.
+        writable=/var/data/mediapipe_models
+        mkdir -p "${store}"
+        for model in "${voice}"/*.tflite; do
+          name=${model##*/}
+          mv -f "${model}" "${store}/${name}"
+          ln -sfn "${writable}/${name}" "${voice}/${name}"
+        done
       # HACK: Patch Discord's app.asar to fix the desktop filename to avoid window association issues, as recommended by the Flatpak documentation:
       #       https://docs.flatpak.org/en/latest/electron.html#using-correct-desktop-file-name
       - patch-electron-desktop-filename /app/discord-canary/resources/app.asar

--- a/discord-canary.sh
+++ b/discord-canary.sh
@@ -41,6 +41,25 @@ then
 fi
 
 disable-breaking-updates.py
+
+# Seed writable copies of MediaPipe *.tflite models (symlinked from /app at build;
+# see com.discordapp.Discord.yaml).
+# Destination matches the build-time symlink target (/var/data == $XDG_DATA_HOME here).
+# See: https://github.com/flathub/com.discordapp.Discord/issues/650
+mediapipe_store=/app/discord-canary/mediapipe_models
+mediapipe_models="${XDG_DATA_HOME:-/var/data}/mediapipe_models"
+if [ ! -d "${mediapipe_models}" ]
+then
+    mkdir -p "${mediapipe_models}"
+fi
+for model in "${mediapipe_store}"/*.tflite
+do
+    if ! cmp -s "${model}" "${mediapipe_models}/${model##*/}"
+    then
+        cp "${model}" "${mediapipe_models}"
+    fi
+done
+
 env TMPDIR="${XDG_CACHE_HOME}" zypak-wrapper /app/discord-canary/DiscordCanary "${FLAGS[@]}" "${DISCORD_FLAGS[@]}" "$@"
 
 if [ "${invoke_socat}" = true ]


### PR DESCRIPTION
This adapts flathub/com.discordapp.Discord@4484897bdf15a398775988588f177a8ade157a78 and flathub/com.discordapp.Discord@06c149cbd163839f0c548c9658fed0f6a9c3112a for DiscordCanary