### PR TITLE
Drop the community package related note

### DIFF
--- a/com.discordapp.DiscordCanary.metainfo.xml
+++ b/com.discordapp.DiscordCanary.metainfo.xml
@@ -16,8 +16,6 @@
   <url type="contact">https://discord.com/company-information</url>
   <icon type="remote" height="256" width="256">https://github.com/flathub/com.discordapp.DiscordCanary/raw/master/com.discordapp.DiscordCanary.png</icon>
   <description>
-    <p>**NOTE: This wrapper is not verified by, affiliated with, or supported by Discord.**</p>
-    <p xml:lang="ru">**ВНИМАНИЕ: Данная оболочка не проверена Discord, не связана и не поддерживается им.**</p>
     <p>Discord is a free all in one messaging, voice, and video client thats available on your computer and phone.</p>
     <p xml:lang="ru">Discord — бесплатный клиент для переписки, голосового и видеообщения, доступный и на компьютере, и на телефоне.</p>
     <p>Whether you’re part of a school club, gaming group, worldwide art community, or just a handful of friends that want to spend time together, Discord makes it easy to talk every day and hang out more often.</p>


### PR DESCRIPTION
No longer required since the Flathub adds the note automatically.